### PR TITLE
Zi cy check purchased item

### DIFF
--- a/src/components/Item.jsx
+++ b/src/components/Item.jsx
@@ -3,7 +3,9 @@ import db from '../lib/firebase';
 
 const Item = ({ name, id, lastPurchasedDate }) => {
   const checkHandler = () => {
-    db.collection('items').doc(id).update({ lastPurchasedDate: new Date() });
+    if (lastPurchasedDate === null || !checked) {
+      db.collection('items').doc(id).update({ lastPurchasedDate: new Date() });
+    }
   };
 
   const checkDate = (lastPurchasedDate) => {
@@ -15,14 +17,12 @@ const Item = ({ name, id, lastPurchasedDate }) => {
       return now - lastPurchasedDate.seconds < day;
     }
   };
+  const checked = checkDate(lastPurchasedDate);
+  const className = checked ? 'checked' : '';
   return (
     <div className="check-item">
-      <input
-        type="checkbox"
-        onChange={checkHandler}
-        checked={checkDate(lastPurchasedDate)}
-      />
-      <li>{name}</li>
+      <input type="checkbox" onChange={checkHandler} checked={checked} />
+      <li className={className}>{name}</li>
     </div>
   );
 };

--- a/src/components/Item.jsx
+++ b/src/components/Item.jsx
@@ -1,36 +1,28 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import db from '../lib/firebase';
 
-const Item = ({ name, id, key }) => {
-  const [purchased, setPurchased] = useState(false);
-  const [purchaseTime, setPurchaseTime] = useState(null);
-  const className = purchased ? 'completed' : '';
+const Item = ({ name, id, lastPurchasedDate }) => {
   const checkHandler = () => {
     db.collection('items').doc(id).update({ lastPurchasedDate: new Date() });
-    checkDate();
   };
 
-  const checkDate = () => {
-    db.collection('items')
-      .doc(id)
-      .get()
-      .then((snapshot) => {
-        let time = snapshot.data().lastPurchasedDate.seconds;
-        setPurchaseTime(time);
-      });
-
-    const day = 60 * 60 * 24;
-    const now = Date.now() / 1000;
-    const checked = now - purchaseTime < day;
-    setPurchased(checked);
+  const checkDate = (lastPurchasedDate) => {
+    if (lastPurchasedDate === null) {
+      return false;
+    } else {
+      const day = 60 * 60 * 24;
+      const now = Date.now() / 1000;
+      return now - lastPurchasedDate.seconds < day;
+    }
   };
-
   return (
     <div className="check-item">
-      <input type="checkbox" onChange={checkHandler} checked={purchased} />
-      <li className={className} key={key}>
-        {name}
-      </li>
+      <input
+        type="checkbox"
+        onChange={checkHandler}
+        checked={checkDate(lastPurchasedDate)}
+      />
+      <li>{name}</li>
     </div>
   );
 };

--- a/src/components/Item.jsx
+++ b/src/components/Item.jsx
@@ -1,0 +1,38 @@
+import React, { useState, useEffect } from 'react';
+import db from '../lib/firebase';
+
+const Item = ({ name, id, key }) => {
+  const [purchased, setPurchased] = useState(false);
+  const [purchaseTime, setPurchaseTime] = useState(null);
+  const className = purchased ? 'completed' : '';
+  const checkHandler = () => {
+    db.collection('items').doc(id).update({ lastPurchasedDate: new Date() });
+    checkDate();
+  };
+
+  const checkDate = () => {
+    db.collection('items')
+      .doc(id)
+      .get()
+      .then((snapshot) => {
+        let time = snapshot.data().lastPurchasedDate.seconds;
+        setPurchaseTime(time);
+      });
+
+    const day = 60 * 60 * 24;
+    const now = Date.now() / 1000;
+    const checked = now - purchaseTime < day;
+    setPurchased(checked);
+  };
+
+  return (
+    <div className="check-item">
+      <input type="checkbox" onChange={checkHandler} checked={purchased} />
+      <li className={className} key={key}>
+        {name}
+      </li>
+    </div>
+  );
+};
+
+export default Item;

--- a/src/components/ShowList.css
+++ b/src/components/ShowList.css
@@ -1,11 +1,9 @@
 .check-item {
   display: flex;
 }
-
 .check-item li {
   list-style: none;
 }
-
-.completed {
-  color: gray;
+.checked {
+  text-decoration: line-through;
 }

--- a/src/components/ShowList.css
+++ b/src/components/ShowList.css
@@ -5,3 +5,7 @@
 .check-item li {
   list-style: none;
 }
+
+.completed {
+  color: gray;
+}

--- a/src/components/ShowList.css
+++ b/src/components/ShowList.css
@@ -1,0 +1,7 @@
+.check-item {
+  display: flex;
+}
+
+.check-item li {
+  list-style: none;
+}

--- a/src/components/ShowList.jsx
+++ b/src/components/ShowList.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useCollection } from 'react-firebase-hooks/firestore';
 import db from '../lib/firebase';
 import Navigation from './Navigation';
+import './ShowList.css';
 
 function ShowList() {
   const token = localStorage.getItem('token');
@@ -19,7 +20,10 @@ function ShowList() {
           Collection:
           <ul>
             {value.docs.map((doc) => (
-              <li key={doc.id}>{doc.data().name}</li>
+              <div className="check-item">
+                <input type="checkbox" />
+                <li key={doc.id}>{doc.data().name}</li>
+              </div>
             ))}
           </ul>
         </div>

--- a/src/components/ShowList.jsx
+++ b/src/components/ShowList.jsx
@@ -1,45 +1,15 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useCollection } from 'react-firebase-hooks/firestore';
 import db from '../lib/firebase';
 import Navigation from './Navigation';
+import Item from './Item';
 import './ShowList.css';
 
 function ShowList() {
-  const [isChecked, setCheck] = useState(false);
-  const [purchaseTime, setPurchaseTime] = useState('');
   const token = localStorage.getItem('token');
   const [value, loading, error] = useCollection(
     db.collection('items').where('token', '==', token),
   );
-
-  const checkHandler = (e) => {
-    const itemId = e.target.id;
-    // apply the logic of apdating lastPurchasedItem
-    db.collection('items')
-      .doc(itemId)
-      .update({ lastPurchasedDate: new Date() });
-
-    db.collection('items')
-      .doc(itemId)
-      .get()
-      .then((snapshot) => setPurchaseTime(snapshot.data().lastPurchasedDate));
-
-    let purchaseDateSecond =
-      purchaseTime.seconds + purchaseTime.nanoseconds / 1000000000;
-
-    const checkDate = () => {
-      const day = 60 * 60 * 24;
-      const now = Date.now() / 1000;
-
-      if (purchaseDateSecond) {
-        const checked = now - purchaseDateSecond < day;
-        return checked;
-      }
-    };
-
-    let checked = checkDate();
-    setCheck(checked);
-  };
   return (
     <div>
       <h1>ListView</h1>
@@ -49,16 +19,8 @@ function ShowList() {
         <div>
           Collection:
           <ul>
-            {value.docs.map((doc) => (
-              <div className="check-item">
-                <input
-                  id={doc.id}
-                  type="checkbox"
-                  onChange={checkHandler}
-                  checked={isChecked}
-                />
-                <li key={doc.id}>{doc.data().name}</li>
-              </div>
+            {value.docs.map((doc, index) => (
+              <Item key={index} {...doc.data()} id={doc.id} />
             ))}
           </ul>
         </div>

--- a/src/components/ShowList.jsx
+++ b/src/components/ShowList.jsx
@@ -1,14 +1,25 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useCollection } from 'react-firebase-hooks/firestore';
 import db from '../lib/firebase';
 import Navigation from './Navigation';
 import './ShowList.css';
 
 function ShowList() {
+  const [isChecked, setCheck] = useState(false);
   const token = localStorage.getItem('token');
   const [value, loading, error] = useCollection(
     db.collection('items').where('token', '==', token),
   );
+
+  const checkHandler = (e) => {
+    const itemId = e.target.id;
+    // apply the logic of apdating lastPurchasedItem
+    db.collection('items')
+      .doc(itemId)
+      .update({ lastPurchasedDate: new Date() });
+
+    setCheck(true);
+  };
 
   return (
     <div>
@@ -21,7 +32,12 @@ function ShowList() {
           <ul>
             {value.docs.map((doc) => (
               <div className="check-item">
-                <input type="checkbox" />
+                <input
+                  id={doc.id}
+                  type="checkbox"
+                  onChange={checkHandler}
+                  // checked
+                />
                 <li key={doc.id}>{doc.data().name}</li>
               </div>
             ))}

--- a/src/components/ShowList.jsx
+++ b/src/components/ShowList.jsx
@@ -19,8 +19,8 @@ function ShowList() {
         <div>
           Collection:
           <ul>
-            {value.docs.map((doc, index) => (
-              <Item key={index} {...doc.data()} id={doc.id} />
+            {value.docs.map((doc) => (
+              <Item key={doc.id} {...doc.data()} id={doc.id} />
             ))}
           </ul>
         </div>

--- a/src/components/ShowList.jsx
+++ b/src/components/ShowList.jsx
@@ -6,6 +6,7 @@ import './ShowList.css';
 
 function ShowList() {
   const [isChecked, setCheck] = useState(false);
+  const [purchaseTime, setPurchaseTime] = useState('');
   const token = localStorage.getItem('token');
   const [value, loading, error] = useCollection(
     db.collection('items').where('token', '==', token),
@@ -18,9 +19,27 @@ function ShowList() {
       .doc(itemId)
       .update({ lastPurchasedDate: new Date() });
 
-    setCheck(true);
-  };
+    db.collection('items')
+      .doc(itemId)
+      .get()
+      .then((snapshot) => setPurchaseTime(snapshot.data().lastPurchasedDate));
 
+    let purchaseDateSecond =
+      purchaseTime.seconds + purchaseTime.nanoseconds / 1000000000;
+
+    const checkDate = () => {
+      const day = 60 * 60 * 24;
+      const now = Date.now() / 1000;
+
+      if (purchaseDateSecond) {
+        const checked = now - purchaseDateSecond < day;
+        return checked;
+      }
+    };
+
+    let checked = checkDate();
+    setCheck(checked);
+  };
   return (
     <div>
       <h1>ListView</h1>
@@ -36,7 +55,7 @@ function ShowList() {
                   id={doc.id}
                   type="checkbox"
                   onChange={checkHandler}
-                  // checked
+                  checked={isChecked}
                 />
                 <li key={doc.id}>{doc.data().name}</li>
               </div>


### PR DESCRIPTION
_For an example of how to fill this template out, [see this Pull Request](https://github.com/the-collab-lab/tcl-3-smart-shopping-list/pull/44)._ 

## Description

The user is able to tap a checkbox and Item should be shown as checked for 24 hours after the purchase is made.

## Related Issue
closes #8 

## Acceptance Criteria
- User is able to tap a checkbox or similar UI element to mark an item in the list as purchased
-Item should be shown as checked for 24 hours after the purchase is made (i.e. we assume the user does not need to buy the item again for at least 1 day)
## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before

<!-- If UI feature, take provide screenshots -->


### After

<!-- If UI feature, take provide screenshots -->


## Testing Steps / QA Criteria

1. Pull down zi-cy-check-purchased-item branch and run npm start
2. check the box of the product you purchased 
3. Check it again before 24 hours, and It won't be unchecked 
4. Go to firestore and change the last purchasedDate to one day/ two days ago and your product will be unchecked automatically. 
