### PR TITLE
CY-NR estimate next purchase date

### DIFF
--- a/src/components/CreateItem.jsx
+++ b/src/components/CreateItem.jsx
@@ -52,7 +52,9 @@ function CreateItem() {
       db.collection('items').add({
         name: item.itemName,
         frequency: item.frequency,
+        numberOfPurchases: 0,
         lastPurchasedDate: null,
+        daysBetweenPurchases: null,
         date: Date().toLocaleString(),
         token,
       });

--- a/src/components/CreateItem.jsx
+++ b/src/components/CreateItem.jsx
@@ -54,8 +54,6 @@ function CreateItem() {
         frequency: item.frequency,
         numberOfPurchases: 0,
         lastPurchasedDate: null,
-        daysBetweenPurchases: null,
-        date: Date().toLocaleString(),
         token,
       });
       setItem(itemObj);

--- a/src/components/CreateItem.jsx
+++ b/src/components/CreateItem.jsx
@@ -9,7 +9,7 @@ function CreateItem() {
   const history = useHistory();
   const itemObj = {
     itemName: '',
-    frequency: '7',
+    nextPurchase: '7',
   };
   const [item, setItem] = useState(itemObj);
   const [notifiction, setNotification] = useState(false);
@@ -51,7 +51,7 @@ function CreateItem() {
     } else {
       db.collection('items').add({
         name: item.itemName,
-        frequency: item.frequency,
+        nextPurchase: parseInt(item.nextPurchase),
         numberOfPurchases: 0,
         lastPurchasedDate: null,
         token,
@@ -90,9 +90,9 @@ function CreateItem() {
               type="radio"
               id="soon"
               value={7}
-              name="frequency"
+              name="nextPurchase"
               onChange={handleChange}
-              checked={item.frequency === '7'}
+              checked={item.nextPurchase === '7'}
             />
             <label htmlFor="soon">Soon</label>
           </div>
@@ -102,9 +102,9 @@ function CreateItem() {
               type="radio"
               id="kind-of-soon"
               value={14}
-              name="frequency"
+              name="nextPurchase"
               onChange={handleChange}
-              checked={item.frequency === '14'}
+              checked={item.nextPurchase === '14'}
             />
             <label htmlFor="kind-of-soon">Kind of soon</label>
           </div>
@@ -114,9 +114,9 @@ function CreateItem() {
               type="radio"
               id="not-soon"
               value={30}
-              name="frequency"
+              name="nextPurchase"
               onChange={handleChange}
-              checked={item.frequency === '30'}
+              checked={item.nextPurchase === '30'}
             />
             <label htmlFor="not-soon">Not soon</label>
           </div>

--- a/src/components/Item.jsx
+++ b/src/components/Item.jsx
@@ -11,13 +11,15 @@ const Item = ({
 }) => {
   const checkHandler = async () => {
     if (lastPurchasedDate === null || !checked) {
-      let purchased = numberOfPurchases + 1;
-      let purchaseInterval = getPurchaseInterval();
-      await db.collection('items').doc(id).update({
-        lastPurchasedDate: new Date(),
-        numberOfPurchases: purchased,
-        daysBetweenPurchases: purchaseInterval,
-      });
+      let nextPurchaseEstimate = getPurchaseInterval();
+      await db
+        .collection('items')
+        .doc(id)
+        .update({
+          lastPurchasedDate: new Date(),
+          numberOfPurchases: numberOfPurchases + 1,
+          frequency: nextPurchaseEstimate,
+        });
     }
   };
 
@@ -42,9 +44,6 @@ const Item = ({
               (60 * 60 * 24),
           )
         : lastEstimate;
-    console.log('lastEstimate', lastEstimate);
-    console.log('latestInterval', latestInterval);
-    console.log('numberOfPurchases', numberOfPurchases);
     let estimatedInterval = calculateEstimate(
       lastEstimate,
       latestInterval,

--- a/src/components/Item.jsx
+++ b/src/components/Item.jsx
@@ -9,16 +9,14 @@ const Item = ({
   lastPurchasedDate,
   numberOfPurchases,
 }) => {
-  const checkHandler = async () => {
+  const checkHandler = () => {
     if (lastPurchasedDate === null || !checked) {
-      let nextPurchaseEstimate = getPurchaseInterval();
-      await db
-        .collection('items')
+      db.collection('items')
         .doc(id)
         .update({
           lastPurchasedDate: new Date(),
           numberOfPurchases: numberOfPurchases + 1,
-          nextPurchase: nextPurchaseEstimate,
+          nextPurchase: getPurchaseInterval(),
         });
     }
   };
@@ -35,11 +33,12 @@ const Item = ({
 
   const getPurchaseInterval = () => {
     let lastEstimate = nextPurchase;
+    let currentDate = new Date().getTime();
     let latestInterval =
       lastPurchasedDate != null
         ? Math.floor(
             // convert from date to seconds
-            (new Date().getTime() / 1000 - lastPurchasedDate.seconds) /
+            (currentDate / 1000 - lastPurchasedDate.seconds) /
               // convert from seconds to day
               (60 * 60 * 24),
           )

--- a/src/components/Item.jsx
+++ b/src/components/Item.jsx
@@ -36,7 +36,7 @@ const Item = ({
     let currentDate = new Date().getTime();
     let latestInterval =
       lastPurchasedDate != null
-        ? Math.floor(
+        ? Math.round(
             // convert from date to seconds
             (currentDate / 1000 - lastPurchasedDate.seconds) /
               // convert from seconds to day

--- a/src/components/Item.jsx
+++ b/src/components/Item.jsx
@@ -5,7 +5,7 @@ import calculateEstimate from '../lib/estimates';
 const Item = ({
   name,
   id,
-  frequency,
+  nextPurchase,
   lastPurchasedDate,
   numberOfPurchases,
 }) => {
@@ -18,7 +18,7 @@ const Item = ({
         .update({
           lastPurchasedDate: new Date(),
           numberOfPurchases: numberOfPurchases + 1,
-          frequency: nextPurchaseEstimate,
+          nextPurchase: nextPurchaseEstimate,
         });
     }
   };
@@ -34,7 +34,7 @@ const Item = ({
   };
 
   const getPurchaseInterval = () => {
-    let lastEstimate = frequency;
+    let lastEstimate = nextPurchase;
     let latestInterval =
       lastPurchasedDate != null
         ? Math.floor(


### PR DESCRIPTION
## Description

We added numberOfPurchase into our database structure. We can then use lastPurchaseDate and numberOfPurchase to update the frequency with calculateEstimate() function to calculate an estimate of when should the user buy the item next time.

## Related Issue

Closes #10 

## Acceptance Criteria

- [x] When a purchase is recorded, the estimated number of days until the next purchase date should be calculated and recorded in the database

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Testing Steps / QA Criteria

1. Pull down `cy-nr-estimate-purchase` branch and run `npm start`
2. Add a new item on the /add-view page and pick 'Soon' on the 'How soon' options. Remember the value of 7 for Soon
3. Navigate to /list-view page and check the box of your newly created item
4. Go to tcl-29-shopping-list firestore and find your newly created item. Make sure the frequency is 7 (from the 'Soon' option) and numberOfPurchases become 1
5. Change the lastPurchasedDate to 2 weeks ago. Go back to /list-view page and check the box of your item
6. Go back to firestore, make sure the frequency is now 14 and numberOfPurchases become 2
7. Change the lastPurchasedDate to 1 week ago. Go back to /list-view page and check the box of your item
8. Go back to firestore, make sure the frequency is now 12 and numberOfPurchases become 3